### PR TITLE
v3 data release

### DIFF
--- a/download_data.sh
+++ b/download_data.sh
@@ -3,9 +3,9 @@ set -e
 set -o pipefail
 
 # Use the OpenPBTA bucket as the default.
-URL=${SPLICE_URL:-https://s3.amazonaws.com/d3b-openaccess-us-east-1-prd-pbta/pbta-germline-somatic}
-RELEASE=${SPLICE_RELEASE:-v2}
-PREVIOUS=${SPLICE_RELEASE:-v1}
+URL=${PBTA_URL:-https://s3.amazonaws.com/d3b-openaccess-us-east-1-prd-pbta/pbta-germline-somatic}
+RELEASE=${PBTA_RELEASE:-v3}
+PREVIOUS=${PBTA_RELEASE:-v2}
 
 # Remove old symlinks in data
 find data -type l -delete


### PR DESCRIPTION
This PR creates v3 data release. The only difference is the histologies file, in which I added BS_ids for normal samples which were missing in the v2 histologies file (aka the v11 OPC histologies file).

Ignore the branch name - didn't realize we are on v3 already!