### PR TITLE
Update to v4 data release

### DIFF
--- a/download_data.sh
+++ b/download_data.sh
@@ -16,26 +16,6 @@ curl --create-dirs $URL/$RELEASE/md5sum.txt -o data/$RELEASE/md5sum.txt -z data/
 # Consider the filenames in the md5sum file and the release notes
 FILES=(`tr -s ' ' < data/$RELEASE/md5sum.txt | cut -d ' ' -f 2` release-notes.md)
 
-if [ -d "data/$PREVIOUS" ]
-then
-  # Find unchanged files
-  echo "Checking for unchanged files..."
-  cd data/$PREVIOUS
-  UNCHANGED=(`md5sum -c ../$RELEASE/md5sum.txt 2>/dev/null | grep OK |cut -d ':' -f 1  || true`)
-  echo $UNCHANGED
-  cd ../../
-
-  # Hard link unchanged files
-  for oldfile in "${UNCHANGED[@]}"
-  do
-    if [ ! -e "data/$RELEASE/$oldfile" ]
-    then
-      echo "Hard linking $oldfile"
-      ln data/$PREVIOUS/$oldfile data/$RELEASE/$oldfile
-    fi
-  done
-fi
-
 # Download the items in FILES if not already present
 for file in "${FILES[@]}"
 do


### PR DESCRIPTION
This PR updates the `download_data.sh` script to pull data from v4 release. The following files were modified or added: 
  - `histologies.tsv` : updated to v12
- `histologies-base.tsv` : 05-10-2023 version added with updated event-free survival data
- `consensus_seg_annotated_cn_autosomes.tsv.gz` : updated v11 autosomal cnv annotation 
- `consensus_seg_annotated_cn_x_and_y.tsv.gz` : updated v11 autosomal cnv annotation 
- `pbta-plp-all-loh.tsv` : LOH scores calculated from germline VAF and matched tumor VAF
- `pbta-all-gene-loh.tsv.gz` : gene LOH scores calculated from germline VAF and matched tumor VAF
- `release-notes.md` : specific notes related to this data release

Please check that data files download correctly and check md5 hashes. 