### PR TITLE
add issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/propose-an-analysis.md
+++ b/.github/ISSUE_TEMPLATE/propose-an-analysis.md
@@ -1,0 +1,32 @@
+---
+name: Propose an analysis
+about: Use this issue template to propose a new analysis
+title: 'Proposed Analysis:'
+labels: proposed analysis
+assignees: ''
+
+---
+
+<!--Hi there! Please take a moment to fill out the template below.-->
+
+#### What are the scientific goals of the analysis?
+
+
+
+#### What methods do you plan to use to accomplish the scientific goals?
+
+
+
+#### What input data are required for this analysis?
+
+
+
+#### How long do you expect is needed to complete the analysis? Will it be a multi-step analysis?
+
+
+#### Who will complete the analysis (please add a GitHub handle here if relevant)?
+
+
+
+#### What relevant scientific literature relates to this analysis?
+

--- a/.github/ISSUE_TEMPLATE/update-an-analysis.md
+++ b/.github/ISSUE_TEMPLATE/update-an-analysis.md
@@ -1,0 +1,30 @@
+---
+name: Update an analysis
+about: Use this issue template to describe an update to a pre-existing analysis module
+title: 'Updated analysis:'
+labels: updated analysis
+assignees: ''
+
+---
+
+<!--Hi there! Please take a moment to fill out the template below.-->
+
+#### What analysis module should be updated and why?
+
+
+
+#### What changes need to be made? Please provide enough detail for another participant to make the update.
+
+
+
+#### What input data should be used? Which data were used in the version being updated?
+
+
+
+#### When do you expect the revised analysis will be completed?
+
+
+
+#### Who will complete the updated analysis?
+
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,70 @@
+<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to 
+facilitate the review of your pull request.-->
+
+### Purpose/implementation Section
+
+#### What scientific question is your analysis addressing?
+
+
+
+#### What was your approach?
+
+
+
+#### What GitHub issue does your pull request address?
+
+
+
+### Directions for reviewers. Tell potential reviewers what kind of feedback you are soliciting.
+
+#### Which areas should receive a particularly close look?
+
+
+
+#### Is there anything that you want to discuss further?
+
+
+
+#### Is the analysis in a mature enough form that the resulting figure(s) and/or table(s) are 
+ready for review?
+
+
+
+### Results
+
+#### What types of results are included (e.g., table, figure)?
+
+
+
+#### What is your summary of the results?
+
+
+
+#### Reproducibility Checklist
+
+<!-- Check all those that apply or remove this section if it is not applicable.-->
+
+- [ ] The dependencies required to run the code in this pull request have been added to the 
+project Dockerfile.
+- [ ] This analysis has been added to continuous integration.
+
+#### Documentation Checklist
+
+<!-- Please review https://github.com/AlexsLemonade/OpenPBTA-analysis#documenting-your-analysis 
+-->
+
+- [ ] This analysis module has a `README` and it is up to date.
+- [ ] This analysis is recorded in the table in `analyses/README.md` and the entry is up to date.
+- [ ] The analytical code is documented and contains comments.
+
+<!-- IF YOUR PULL REQUEST IS A DATA RELEASE, PLEASE REMOVE THE [HTML COMMENT 
+TAG](https://html.com/tags/comment-tag/) FROM THE SECTION BELOW AND COMPLETE THE CHECKLIST-->
+
+<!-- 
+### Data Release Checklist
+- [ ] Is the table in doc/data-file-descriptions.md up to date?
+- [ ] Is doc/data-format.md up to date?
+- [ ] Is doc/release-notes.md up to date?
+- [ ] Is download-data.sh up to date?
+- [ ] Was download-data.sh tested and did it complete without error?
+-->


### PR DESCRIPTION
This PR adds issue and pull request template markdown files for use by contributors to the repository. All templates were copied over from the [OpenPedCan-analysis](https://github.com/d3b-center/OpenPedCan-analysis/tree/dev/.github) repo. This PR addresses issue #45 