### PR TITLE
update Dockerfile with openxlsx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,9 +68,6 @@ RUN ./install_bioc.r \
 # Maftools
 RUN ./install_github.r \
 	PoisonAlien/maftools
-	
-#RUN ./install_github.r \
-#	clauswilke/colorblindr
 
 
 # Patchwork for plot compositions


### PR DESCRIPTION
This PR closes #78 by adding `openxlsx` to Dockerfile. Please pull latest image and confirm it has been added successfully. 

`docker pull pgc-images.sbgenomics.com/corbettr/pbta-germline:latest`